### PR TITLE
Simplify footer and use router links for same-page links

### DIFF
--- a/spoopy-site/src/footer/Footer.css
+++ b/spoopy-site/src/footer/Footer.css
@@ -1,24 +1,25 @@
-.page-footer {
+footer {
     bottom: 0;
     position: fixed;
     width: 100%;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    border-top: 3px solid lightslategray;
     font-size: 20px;
     text-align: center;
+    background-color: white;
 }
 
-.footer-copyright div p {
+footer p {
     padding: 0;
     margin: 0;
 }
 
-.footer-copyright {
-    background-color: white;
-    border-top-width: 3px;
-    border-top-style: solid;
-    border-color: lightslategray;
+footer a {
+    display: inline-block;
+    padding: 2px;
 }
 
-.container {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+.inspiration {
+    font-size: 15px;
 }

--- a/spoopy-site/src/footer/Footer.js
+++ b/spoopy-site/src/footer/Footer.js
@@ -1,18 +1,19 @@
 import React, { Component } from "react";
+import { Link } from "react-router-dom";
 import "./Footer.css";
 
 class Footer extends Component {
   render() {
     return (
-      <footer className="page-footer">
-        <div className="footer-copyright">
-          <div className="container">
-            <p>Inspired by <a href="https://github.com/spoopy-link/server">spoopy</a>. Source at <a
-              href="https://github.com/Lagicrus/spoopy-python">Github</a></p>
-            <p className="subFooter">Docs can be found <a href="/docs">here</a>. Homepage
-            located <a href="/">here</a></p>
-          </div>
-        </div>
+      <footer>
+        <p>
+          <Link to="/">Home</Link>
+          <Link to="/docs">Docs</Link>
+          <a href="https://github.com/Lagicrus/spoopy-python">GitHub</a>
+        </p>
+        <p className="inspiration">
+          Inspired by <a href="https://github.com/spoopy-link/server">spoopy link</a>
+        </p>
       </footer>
     );
   }


### PR DESCRIPTION
beep.

Fixes the usage of the docs and home links reloading the app, and simplifies the footer a bit as discussed on Discord.